### PR TITLE
fixed serialization bug

### DIFF
--- a/modules/data/src/main/java/io/fluo/webindex/serialization/WebindexKryoFactory.java
+++ b/modules/data/src/main/java/io/fluo/webindex/serialization/WebindexKryoFactory.java
@@ -33,12 +33,15 @@ public class WebindexKryoFactory implements KryoFactory, Serializable {
   public Kryo create() {
     Kryo kryo = new Kryo();
 
-    kryo.register(UriInfo.class);
-    kryo.register(DomainExport.class);
-    kryo.register(UriCountExport.class);
-    kryo.register(PageExport.class);
-    kryo.register(ArrayList.class);
-    kryo.register(Link.class);
+    // Explicitly set class ids when registering. Did not set ids (because thought if registered in
+    // same order it would be ok) and ran into issue where Spark and Fluo code were using different
+    // ids for some reason.
+    kryo.register(UriInfo.class, 9);
+    kryo.register(DomainExport.class, 10);
+    kryo.register(UriCountExport.class, 11);
+    kryo.register(PageExport.class, 12);
+    kryo.register(ArrayList.class, 13);
+    kryo.register(Link.class, 14);
 
     kryo.setRegistrationRequired(true);
 

--- a/modules/data/src/test/resources/data/set1/fluo-data.txt
+++ b/modules/data/src/test/resources/data/set1/fluo-data.txt
@@ -3,9 +3,9 @@ dm:d:87:\x03\x01com.\xe1|data|current|\x09\x02
 dm:d:90:\x03\x01com.\xe2|data|current|\x09\x08
 p:com.a/1|page|cur|{"url":"http://a.com/1","numOutbound":3,"outboundLinks":[{"url":"http://b.com/3","anchorText":"b3"},{"url":"http://c.com/1","anchorText":"c1"},{"url":"http://b.com/1","anchorText":"b1"}]}
 p:com.b|page|cur|{"url":"http://b.com","numOutbound":3,"outboundLinks":[{"url":"http://b.com/2","anchorText":"b2"},{"url":"http://b.com/3","anchorText":"b3"},{"url":"http://c.com/1","anchorText":"c1"}]}
-um:d:110:\x03\x01com.b/\xb1|data|current|\x0c\x01\x00\x02
-um:d:31:\x03\x01com.c/\xb1|data|current|\x0c\x01\x00\x04
-um:d:45:\x03\x01com.b/\xb2|data|current|\x0c\x01\x00\x02
-um:d:63:\x03\x01com.b/\xb3|data|current|\x0c\x01\x00\x04
-um:d:87:\x03\x01com.a/\xb1|data|current|\x0c\x01\x02\x00
-um:d:90:\x03\x01com.\xe2|data|current|\x0c\x01\x02\x00
+um:d:110:\x03\x01com.b/\xb1|data|current|\x0b\x01\x00\x02
+um:d:31:\x03\x01com.c/\xb1|data|current|\x0b\x01\x00\x04
+um:d:45:\x03\x01com.b/\xb2|data|current|\x0b\x01\x00\x02
+um:d:63:\x03\x01com.b/\xb3|data|current|\x0b\x01\x00\x04
+um:d:87:\x03\x01com.a/\xb1|data|current|\x0b\x01\x02\x00
+um:d:90:\x03\x01com.\xe2|data|current|\x0b\x01\x02\x00


### PR DESCRIPTION
While running web index on a single node YARN and Accumulo system (setup by
fluo-dev) I ran into a bug.  When the collision free map deserialized UriInfo
objects they were null.  I traced the problem down to Spark and Fluo code using
different IDs when serializing/deserializing UriInfo.   Explicitly setting the
id when registering classes with Kryo fixed the issue.