### PR TITLE
Add split point for end of pages range in table data.

### DIFF
--- a/modules/data/src/main/java/io/fluo/webindex/data/CalcSplits.java
+++ b/modules/data/src/main/java/io/fluo/webindex/data/CalcSplits.java
@@ -66,7 +66,7 @@ public class CalcSplits {
     splits = IndexUtil.calculateSplits(fluoIndex, 100);
     log.info("Fluo splits:");
     splits.forEach(System.out::println);
-
+    System.out.println("p:~");
     ctx.stop();
   }
 }

--- a/modules/data/src/main/resources/splits/fluo-default.txt
+++ b/modules/data/src/main/resources/splits/fluo-default.txt
@@ -41,3 +41,4 @@ p:org.jt
 p:org.pl
 p:org.wq
 p:uk.co.v
+p:~

--- a/modules/data/src/test/java/io/fluo/webindex/data/spark/IndexEnvTest.java
+++ b/modules/data/src/test/java/io/fluo/webindex/data/spark/IndexEnvTest.java
@@ -32,8 +32,8 @@ public class IndexEnvTest {
 
     splits = IndexEnv.getFluoDefaultSplits();
 
-    Assert.assertEquals(43, splits.size());
+    Assert.assertEquals(44, splits.size());
     Assert.assertEquals(new Text("p:c"), splits.first());
-    Assert.assertEquals(new Text("p:uk.co.v"), splits.last());
+    Assert.assertEquals(new Text("p:~"), splits.last());
   }
 }


### PR DESCRIPTION
I noticed that the first Uri collision free map tablet
also contained page data for the end of the page range.
Adding a split point to create a last tablet for page
data.